### PR TITLE
Added endpoint for partial playlist details update

### DIFF
--- a/src/main/java/com/odeyalo/sonata/playlists/dto/PartialPlaylistDetailsUpdateRequest.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/dto/PartialPlaylistDetailsUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.odeyalo.sonata.playlists.dto;
+
+import com.odeyalo.sonata.playlists.model.PlaylistType;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * Body to partial updates of the playlist details
+ */
+@Data
+@AllArgsConstructor(staticName = "of")
+@NoArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class PartialPlaylistDetailsUpdateRequest {
+    String name;
+    String description;
+    PlaylistType playlistType;
+
+    public static PartialPlaylistDetailsUpdateRequest nameOnly(String name) {
+        return builder().name(name).build();
+    }
+
+    public static PartialPlaylistDetailsUpdateRequest descriptionOnly(String description) {
+        return builder().description(description).build();
+    }
+
+    public static PartialPlaylistDetailsUpdateRequest playlistTypeOnly(PlaylistType playlistType) {
+        return builder().playlistType(playlistType).build();
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/playlists/controller/PartialPlaylistUpdateEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/controller/PartialPlaylistUpdateEndpointTest.java
@@ -1,0 +1,274 @@
+package com.odeyalo.sonata.playlists.controller;
+
+import com.odeyalo.sonata.playlists.dto.CreatePlaylistRequest;
+import com.odeyalo.sonata.playlists.dto.PartialPlaylistDetailsUpdateRequest;
+import com.odeyalo.sonata.playlists.dto.PlaylistDto;
+import com.odeyalo.sonata.playlists.model.PlaylistType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import testing.QaControllerOperations;
+import testing.SonataPlaylistHttpTestClient;
+import testing.asserts.PlaylistDtoAssert;
+import testing.spring.autoconfigure.AutoConfigureQaEnvironment;
+import testing.spring.autoconfigure.AutoConfigureSonataPlaylistHttpClient;
+
+import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.REMOTE;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureWebTestClient
+@AutoConfigureSonataPlaylistHttpClient
+@AutoConfigureQaEnvironment
+@AutoConfigureStubRunner(stubsMode = REMOTE,
+        repositoryRoot = "${spring.contracts.repository.root}",
+        ids = "com.odeyalo.sonata:authorization:+")
+@TestPropertySource(locations = "classpath:application-test.properties")
+public class PartialPlaylistUpdateEndpointTest {
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @Autowired
+    SonataPlaylistHttpTestClient playlistHttpTestClient;
+
+    @Autowired
+    QaControllerOperations qaControllerOperations;
+
+    String VALID_ACCESS_TOKEN = "Bearer mikunakanoisthebestgirl";
+    String VALID_USER_ID = "1";
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class UpdatePlaylistNameTests {
+        private PlaylistDto existingPlaylist;
+
+        @BeforeEach
+        void setUp() {
+            CreatePlaylistRequest body = CreatePlaylistRequest.builder()
+                    .name("Best LO-FI 2023")
+                    .description("Compilation of best LO-FI tracks 2023")
+                    .build();
+            existingPlaylist = playlistHttpTestClient.createPlaylist(VALID_ACCESS_TOKEN, VALID_USER_ID, body);
+        }
+
+        @AfterEach
+        void tearDown() {
+            qaControllerOperations.clearPlaylists();
+        }
+
+        @Test
+        void shouldReturn204NoContent() {
+            PartialPlaylistDetailsUpdateRequest body = PartialPlaylistDetailsUpdateRequest.nameOnly("Best chill phonk 2023");
+
+            WebTestClient.ResponseSpec responseSpec = sendRequest(body, existingPlaylist.getId());
+
+            responseSpec.expectStatus().isNoContent();
+        }
+
+        @Test
+        void shouldUpdatePlaylistName() {
+            String newName = "Best chill phonk 2023";
+            PartialPlaylistDetailsUpdateRequest body = PartialPlaylistDetailsUpdateRequest.nameOnly(newName);
+            // when
+            sendRequest(body, existingPlaylist.getId());
+
+            // then
+            PlaylistDto updatedPlaylist = fetchPlaylist(existingPlaylist.getId());
+
+            PlaylistDtoAssert.forPlaylist(updatedPlaylist).name().isEqualTo(newName);
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class UpdatePlaylistDescriptionTests {
+        private PlaylistDto existingPlaylist;
+
+        @BeforeEach
+        void setUp() {
+            CreatePlaylistRequest body = CreatePlaylistRequest.builder()
+                    .name("Best LO-FI 2023")
+                    .description("Compilation of best LO-FI tracks 2023")
+                    .build();
+            existingPlaylist = playlistHttpTestClient.createPlaylist(VALID_ACCESS_TOKEN, VALID_USER_ID, body);
+        }
+
+        @AfterEach
+        void tearDown() {
+            qaControllerOperations.clearPlaylists();
+        }
+
+        @Test
+        void shouldReturn204NoContent() {
+            PartialPlaylistDetailsUpdateRequest body = PartialPlaylistDetailsUpdateRequest.descriptionOnly("Compilation of the best phonk in 2023");
+
+            WebTestClient.ResponseSpec responseSpec = sendRequest(body, existingPlaylist.getId());
+
+            responseSpec.expectStatus().isNoContent();
+        }
+
+        @Test
+        void shouldUpdatePlaylistName() {
+            String newDescription = "Compilation of the best phonk in 2023";
+            PartialPlaylistDetailsUpdateRequest body = PartialPlaylistDetailsUpdateRequest.descriptionOnly(newDescription);
+            // when
+            sendRequest(body, existingPlaylist.getId());
+
+            // then
+            PlaylistDto updatedPlaylist = fetchPlaylist(existingPlaylist.getId());
+
+            PlaylistDtoAssert.forPlaylist(updatedPlaylist).description().isEqualTo(newDescription);
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class UpdatePlaylistTypeTests {
+        private PlaylistDto existingPlaylist;
+
+        @BeforeEach
+        void setUp() {
+            CreatePlaylistRequest body = CreatePlaylistRequest.builder()
+                    .name("Best LO-FI 2023")
+                    .description("Compilation of best LO-FI tracks 2023")
+                    .type(PlaylistType.PUBLIC)
+                    .build();
+            existingPlaylist = playlistHttpTestClient.createPlaylist(VALID_ACCESS_TOKEN, VALID_USER_ID, body);
+        }
+
+        @AfterEach
+        void tearDown() {
+            qaControllerOperations.clearPlaylists();
+        }
+
+        @Test
+        void shouldReturn204NoContent() {
+            PartialPlaylistDetailsUpdateRequest body = PartialPlaylistDetailsUpdateRequest.playlistTypeOnly(PlaylistType.PRIVATE);
+
+            WebTestClient.ResponseSpec responseSpec = sendRequest(body, existingPlaylist.getId());
+
+            responseSpec.expectStatus().isNoContent();
+        }
+
+        @Test
+        void shouldUpdatePlaylistName() {
+            PlaylistType newPlaylistType = PlaylistType.PRIVATE;
+            PartialPlaylistDetailsUpdateRequest body = PartialPlaylistDetailsUpdateRequest.playlistTypeOnly(newPlaylistType);
+            // when
+            sendRequest(body, existingPlaylist.getId());
+            // then
+            PlaylistDto updatedPlaylist = fetchPlaylist(existingPlaylist.getId());
+
+            PlaylistDtoAssert.forPlaylist(updatedPlaylist).playlistType().isEqualTo(newPlaylistType);
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AllFieldsUpdateTests {
+        private PlaylistDto existingPlaylist;
+
+        @BeforeEach
+        void setUp() {
+            CreatePlaylistRequest body = CreatePlaylistRequest.builder()
+                    .name("Best LO-FI 2023")
+                    .description("Compilation of best LO-FI tracks 2023")
+                    .type(PlaylistType.PUBLIC)
+                    .build();
+            existingPlaylist = playlistHttpTestClient.createPlaylist(VALID_ACCESS_TOKEN, VALID_USER_ID, body);
+        }
+
+        @AfterEach
+        void tearDown() {
+            qaControllerOperations.clearPlaylists();
+        }
+
+        @Test
+        void shouldReturn204Status() {
+            PartialPlaylistDetailsUpdateRequest body = PartialPlaylistDetailsUpdateRequest.of("Best Phonk 2023", "Compilation of best tracks in 2023", PlaylistType.PRIVATE);
+
+            WebTestClient.ResponseSpec responseSpec = sendRequest(body, existingPlaylist.getId());
+
+            responseSpec.expectStatus().isNoContent();
+        }
+
+        @Test
+        void shouldUpdateName() {
+            PartialPlaylistDetailsUpdateRequest body = getBody();
+
+            sendRequest(body, existingPlaylist.getId());
+
+            PlaylistDto playlistDto = fetchPlaylist(existingPlaylist.getId());
+
+            PlaylistDtoAssert.forPlaylist(playlistDto).name().isEqualTo(body.getName());
+        }
+
+        @Test
+        void shouldUpdateDescription() {
+            PartialPlaylistDetailsUpdateRequest body = getBody();
+
+            sendRequest(body, existingPlaylist.getId());
+
+            PlaylistDto playlistDto = fetchPlaylist(existingPlaylist.getId());
+
+            PlaylistDtoAssert.forPlaylist(playlistDto).description().isEqualTo(body.getDescription());
+        }
+
+        @Test
+        void shouldUpdatePlaylistType() {
+            PartialPlaylistDetailsUpdateRequest body = getBody();
+
+            sendRequest(body, existingPlaylist.getId());
+
+            PlaylistDto playlistDto = fetchPlaylist(existingPlaylist.getId());
+
+            PlaylistDtoAssert.forPlaylist(playlistDto).playlistType().isEqualTo(body.getPlaylistType());
+        }
+
+
+        private PartialPlaylistDetailsUpdateRequest getBody() {
+            return PartialPlaylistDetailsUpdateRequest.builder()
+                    .name("Best Phonk 2023")
+                    .description("Compilation of best tracks in 2023")
+                    .playlistType(PlaylistType.PRIVATE)
+                    .build();
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class NotExistingPlaylistTests {
+
+        @Test
+        void shouldReturn422Status() {
+            PartialPlaylistDetailsUpdateRequest body = PartialPlaylistDetailsUpdateRequest.nameOnly("New name");
+
+            WebTestClient.ResponseSpec responseSpec = sendRequest(body, "not existing");
+
+            responseSpec.expectStatus().isEqualTo(UNPROCESSABLE_ENTITY);
+        }
+    }
+
+    @NotNull
+    private WebTestClient.ResponseSpec sendRequest(PartialPlaylistDetailsUpdateRequest body, String playlistId) {
+        return webTestClient.patch()
+                .uri("/playlist/{playlistId}", playlistId)
+                .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .exchange();
+    }
+
+    private PlaylistDto fetchPlaylist(String playlistId) {
+        return playlistHttpTestClient.fetchPlaylist(VALID_ACCESS_TOKEN, playlistId);
+    }
+}


### PR DESCRIPTION
Added endpoint for partial playlist details update
Written tests.
Partial update using PATCH method /playlist/{playlistId} url
Fields supported:
- playlist name
- playlist description
- playlist type