### PR TITLE
Fixed bug with postgres and images

### DIFF
--- a/src/main/java/com/odeyalo/sonata/playlists/entity/R2dbcPlaylistEntity.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/R2dbcPlaylistEntity.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Persistable;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -26,7 +27,8 @@ public class R2dbcPlaylistEntity implements PlaylistEntity, Persistable<Long> {
     String playlistDescription;
     PlaylistType playlistType = PlaylistType.PRIVATE;
     @Transient
-    List<PlaylistImage> images;
+    @Builder.Default
+    List<PlaylistImage> images = new ArrayList<>();
 
     @Override
     public boolean isNew() {

--- a/src/main/java/com/odeyalo/sonata/playlists/repository/PlaylistImagesRepository.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/repository/PlaylistImagesRepository.java
@@ -4,10 +4,12 @@ import com.odeyalo.sonata.playlists.entity.PlaylistImage;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Repository
 public interface PlaylistImagesRepository extends ReactiveCrudRepository<PlaylistImage, Long> {
 
     Flux<PlaylistImage> findAllByPlaylistId(Long playlistId);
 
+    Mono<Void> deleteAllByPlaylistId(Long id);
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/repository/PlaylistImagesRepository.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/repository/PlaylistImagesRepository.java
@@ -1,0 +1,13 @@
+package com.odeyalo.sonata.playlists.repository;
+
+import com.odeyalo.sonata.playlists.entity.PlaylistImage;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+@Repository
+public interface PlaylistImagesRepository extends ReactiveCrudRepository<PlaylistImage, Long> {
+
+    Flux<PlaylistImage> findAllByPlaylistId(Long playlistId);
+
+}

--- a/src/main/java/com/odeyalo/sonata/playlists/repository/R2dbcImageEntityRepository.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/repository/R2dbcImageEntityRepository.java
@@ -1,8 +1,10 @@
 package com.odeyalo.sonata.playlists.repository;
 
 import com.odeyalo.sonata.playlists.entity.R2dbcImageEntity;
-import com.odeyalo.sonata.playlists.entity.R2dbcPlaylistEntity;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
 
 public interface R2dbcImageEntityRepository extends ReactiveCrudRepository<R2dbcImageEntity, Long> {
+
+    Mono<R2dbcImageEntity> findByUrl(String url);
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/service/upload/MockImageUploader.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/upload/MockImageUploader.java
@@ -5,6 +5,8 @@ import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+
 /**
  * ImageUploader impl that always returns the same value
  */
@@ -13,6 +15,6 @@ public class MockImageUploader implements ImageUploader {
 
     @Override
     public Mono<Image> uploadImage(Mono<FilePart> filePart) {
-        return Mono.just(Image.urlOnly("https:/cdn.sonata.com/mikunakano"));
+        return Mono.just(Image.urlOnly(String.format("https:/cdn.sonata.com/%s", randomAlphanumeric(50))));
     }
 }

--- a/src/main/resources/db/migration/V4__unique_image_url_constraint.sql
+++ b/src/main/resources/db/migration/V4__unique_image_url_constraint.sql
@@ -1,0 +1,2 @@
+-- Multiple images can't have the same URL even if they have different width/height
+ALTER TABLE images ADD CONSTRAINT unique_image_url UNIQUE (url)

--- a/src/test/java/com/odeyalo/sonata/playlists/controller/PlaylistImageUploadEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/controller/PlaylistImageUploadEndpointTest.java
@@ -114,6 +114,33 @@ public class PlaylistImageUploadEndpointTest {
             PlaylistDtoAssert.forPlaylist(fetched).images().peekFirst().url().isNotNull();
         }
 
+        @Test
+        void updateImageSeveralTimesAndExpectOnlyOneImageInResponse() {
+            String playlistId = existingPlaylist.getId();
+            // when
+            sendRequest(playlistId);
+            sendRequest(playlistId);
+            sendRequest(playlistId);
+            // then
+            PlaylistDto fetched = fetchPlaylist(playlistId);
+            PlaylistDtoAssert.forPlaylist(fetched).images().length(1);
+        }
+
+        @Test
+        void shouldChangeOnlyImageAndNothingElse() {
+            String playlistId = existingPlaylist.getId();
+            // when
+            sendRequest(playlistId);
+            // then
+            PlaylistDto fetched = fetchPlaylist(playlistId);
+
+            PlaylistDtoAssert.forPlaylist(fetched).images().peekFirst().url().isNotNull();
+            PlaylistDtoAssert.forPlaylist(fetched).id().isEqualTo(existingPlaylist.getId());
+            PlaylistDtoAssert.forPlaylist(fetched).name().isEqualTo(existingPlaylist.getName());
+            PlaylistDtoAssert.forPlaylist(fetched).description().isEqualTo(existingPlaylist.getDescription());
+            PlaylistDtoAssert.forPlaylist(fetched).playlistType().isEqualTo(existingPlaylist.getPlaylistType());
+        }
+
         private WebTestClient.ResponseSpec prepareAndSend() {
             return sendRequest(existingPlaylist.getId());
         }


### PR DESCRIPTION
Fixed bug with postgres and images when playlist was associated with multiple images.
Now every playlist can have only one image.
Added UNIQUE constraint to 'images' table for 'url' field.
Written additional tests to check the bug does not exist.