### PR TITLE
Added index for playlist item

### DIFF
--- a/src/main/java/com/odeyalo/sonata/playlists/entity/PlaylistItemEntity.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/PlaylistItemEntity.java
@@ -18,9 +18,13 @@ import java.time.Instant;
 public class PlaylistItemEntity {
     @Id
     Long id;
+    @NotNull
     Instant addedAt;
     @NotNull
     PlaylistCollaboratorEntity addedBy;
+    @NotNull
     ItemEntity item;
+    @NotNull
     String playlistId;
+    int index;
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/repository/InMemoryPlaylistItemsRepository.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/repository/InMemoryPlaylistItemsRepository.java
@@ -8,12 +8,14 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 
 /**
  * In memory implementation of {@link PlaylistItemsRepository} that saves the values in simple {@link Map}
@@ -38,6 +40,8 @@ public final class InMemoryPlaylistItemsRepository implements PlaylistItemsRepos
         final int limit = pageable.isUnpaged() ? 50 : pageable.getPageSize();
 
         List<PlaylistItemEntity> items = cache.getOrDefault(playlistId, Collections.emptyList());
+
+        items.sort(Comparator.comparingInt(PlaylistItemEntity::getIndex));
 
         return Flux.fromIterable(items)
                 .skip(offset)

--- a/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistTracksEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistTracksEndpointTest.java
@@ -59,6 +59,7 @@ import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerPro
 @ActiveProfiles("test")
 @Import(TestConfig.class)
 class FetchPlaylistTracksEndpointTest {
+
     @Autowired
     WebTestClient webTestClient;
 
@@ -72,7 +73,8 @@ class FetchPlaylistTracksEndpointTest {
 
     static final PlaylistItemEntity PLAYLIST_ITEM_1 = PlaylistItemEntity.of(
             1L,
-            Instant.now(), PlaylistCollaboratorEntityFaker.create().get(),
+            Instant.now(),
+            PlaylistCollaboratorEntityFaker.create().get(),
             ItemEntity.of(1L, TRACK_1_ID, "sonata:track:" + TRACK_1_ID),
             EXISTING_PLAYLIST_ID,
             0);
@@ -216,6 +218,19 @@ class FetchPlaylistTracksEndpointTest {
         assertThat(responseBody.getItems())
                 .map(it -> it.getItem().getId())
                 .hasSameElementsAs(List.of(TRACK_2_ID));
+    }
+
+    @Test
+    void shouldReturnItemsSortedByIndex() {
+        final WebTestClient.ResponseSpec responseSpec = fetchPlaylistItems();
+
+        final PlaylistItemsDto responseBody = responseSpec.expectBody(PlaylistItemsDto.class)
+                .returnResult().getResponseBody();
+
+        //noinspection DataFlowIssue
+        assertThat(responseBody.getItems())
+                .map(it -> it.getItem().getId())
+                .containsExactly(TRACK_1_ID, TRACK_2_ID, TRACK_3_ID);
     }
 
     @Test

--- a/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistTracksEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistTracksEndpointTest.java
@@ -74,21 +74,25 @@ class FetchPlaylistTracksEndpointTest {
             1L,
             Instant.now(), PlaylistCollaboratorEntityFaker.create().get(),
             ItemEntity.of(1L, TRACK_1_ID, "sonata:track:" + TRACK_1_ID),
-            EXISTING_PLAYLIST_ID);
+            EXISTING_PLAYLIST_ID,
+            0);
 
     static final PlaylistItemEntity PLAYLIST_ITEM_2 = PlaylistItemEntity.of(
             2L,
             Instant.now(),
             PlaylistCollaboratorEntityFaker.create().get(),
             ItemEntity.of(2L, TRACK_2_ID,
-                    "sonata:track:" + TRACK_2_ID), EXISTING_PLAYLIST_ID);
+                    "sonata:track:" + TRACK_2_ID),
+            EXISTING_PLAYLIST_ID,
+            1);
 
     static final PlaylistItemEntity PLAYLIST_ITEM_3 = PlaylistItemEntity.of(
             3L,
             Instant.now(),
             PlaylistCollaboratorEntityFaker.create().get(),
             ItemEntity.of(3L, TRACK_3_ID, "sonata:track:" + TRACK_3_ID),
-            EXISTING_PLAYLIST_ID);
+            EXISTING_PLAYLIST_ID,
+            2);
 
     static final TrackPlayableItem PLAYABLE_ITEM_1 = TrackPlayableItemFaker.create().setPublicId(TRACK_1_ID).get();
 

--- a/src/test/java/com/odeyalo/sonata/playlists/repository/InMemoryPlaylistItemsRepositoryTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/repository/InMemoryPlaylistItemsRepositoryTest.java
@@ -109,6 +109,28 @@ class InMemoryPlaylistItemsRepositoryTest {
     }
 
     @Test
+    void shouldSortPlaylistItemsAccordingByItemPosition() {
+        final String playlistId = "1";
+
+        final var playlistItem1 = PlaylistItemEntityFaker.create(playlistId).withIndex(0).get();
+        final var playlistItem2 = PlaylistItemEntityFaker.create(playlistId).withIndex(1).get();
+        final var playlistItem3 = PlaylistItemEntityFaker.create(playlistId).withIndex(2).get();
+
+        final List<PlaylistItemEntity> playlistItems = List.of(
+                playlistItem3,
+                playlistItem1,
+                playlistItem2
+        );
+
+        final var testable = new InMemoryPlaylistItemsRepository(playlistItems);
+
+        testable.findAllByPlaylistId(playlistId, Pageable.unpaged())
+                .as(StepVerifier::create)
+                .expectNext(playlistItem1, playlistItem2, playlistItem3)
+                .verifyComplete();
+    }
+
+    @Test
     void shouldReturnEntityUnchangedIfIdIsSet() {
         final String playlistId = "1";
         final PlaylistItemEntity entity = PlaylistItemEntityFaker.create(playlistId).get();

--- a/src/test/java/testing/PlaylistItemEntityFaker.java
+++ b/src/test/java/testing/PlaylistItemEntityFaker.java
@@ -37,4 +37,9 @@ public final class PlaylistItemEntityFaker {
         builder.id(id);
         return this;
     }
+
+    public PlaylistItemEntityFaker withIndex(int index) {
+        builder.index(index);
+        return this;
+    }
 }


### PR DESCRIPTION
Added index for playlist item.
Playlist items are now sorted by this index, instead of random order. 
No SQL migrations are written. Only the in-memory version is using now.    