### PR TITLE
Added context uri to playlist.

### DIFF
--- a/src/main/java/com/odeyalo/sonata/playlists/dto/PlaylistDto.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/dto/PlaylistDto.java
@@ -21,6 +21,8 @@ public class PlaylistDto {
     String name;
     @JsonProperty("description")
     String description;
+    @JsonProperty("context_uri")
+    String contextUri;
     @JsonProperty("playlist_type")
     PlaylistType playlistType;
     @JsonProperty("type")

--- a/src/main/java/com/odeyalo/sonata/playlists/entity/PlaylistEntity.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/PlaylistEntity.java
@@ -25,6 +25,8 @@ public class PlaylistEntity implements Persistable<Long> {
     String publicId;
     String playlistName;
     String playlistDescription;
+    @Column("context_uri")
+    String contextUri;
     PlaylistType playlistType = PlaylistType.PRIVATE;
     @Column("owner_id")
     Long playlistOwnerId;

--- a/src/main/java/com/odeyalo/sonata/playlists/model/Playlist.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/model/Playlist.java
@@ -1,5 +1,6 @@
 package com.odeyalo.sonata.playlists.model;
 
+import com.odeyalo.sonata.common.context.ContextUri;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
@@ -19,6 +20,7 @@ public class Playlist {
     String id;
     String name;
     String description;
+    ContextUri contextUri;
     @Builder.Default
     PlaylistType playlistType = PlaylistType.PRIVATE;
     @Builder.Default

--- a/src/main/java/com/odeyalo/sonata/playlists/repository/InMemoryPlaylistRepository.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/repository/InMemoryPlaylistRepository.java
@@ -1,5 +1,6 @@
 package com.odeyalo.sonata.playlists.repository;
 
+import com.odeyalo.sonata.common.context.ContextUri;
 import com.odeyalo.sonata.playlists.model.Playlist;
 import org.apache.commons.lang.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -64,7 +65,7 @@ public class InMemoryPlaylistRepository implements PlaylistRepository {
 
         if ( id == null ) {
             id = RandomStringUtils.randomAlphanumeric(15);
-            playlist = Playlist.from(playlist).id(id).build();
+            playlist = Playlist.from(playlist).id(id).contextUri(ContextUri.forPlaylist(id)).build();
         }
 
         return playlist;

--- a/src/main/java/com/odeyalo/sonata/playlists/repository/r2dbc/R2dbcPlaylistRepository.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/repository/r2dbc/R2dbcPlaylistRepository.java
@@ -71,6 +71,7 @@ public final class R2dbcPlaylistRepository implements PlaylistRepository {
 
         PlaylistEntity entity = playlistConverter.toPlaylistEntity(playlist);
         entity.setId(parent.getId());
+        entity.setContextUri("sonata:playlist:" + entity.getPublicId());
 
         return playlistRepositoryDelegate.save(entity);
     }
@@ -80,6 +81,8 @@ public final class R2dbcPlaylistRepository implements PlaylistRepository {
         String playlistId = playlist.getId() != null ? playlist.getId() : RandomStringUtils.randomAlphanumeric(22);
         PlaylistEntity entity = playlistConverter.toPlaylistEntity(playlist);
         entity.setPublicId(playlistId);
+        entity.setContextUri("sonata:playlist:" + playlistId);
+
         return entity;
     }
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistConverter.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistConverter.java
@@ -1,5 +1,6 @@
 package com.odeyalo.sonata.playlists.support.converter;
 
+import com.odeyalo.sonata.common.context.ContextUri;
 import com.odeyalo.sonata.playlists.entity.PlaylistEntity;
 import com.odeyalo.sonata.playlists.model.Playlist;
 import org.mapstruct.Mapper;
@@ -8,17 +9,21 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring", uses = {
         ImagesEntityConverter.class,
         PlaylistOwnerConverter.class
+}, imports = {
+        ContextUri.class
 })
 public interface PlaylistConverter {
 
     @Mapping(target = "id", source = "publicId")
     @Mapping(target = "name", source = "playlistName")
     @Mapping(target = "description", source = "playlistDescription")
+    @Mapping(target = "contextUri", expression = "java( ContextUri.fromString( playlistEntity.getContextUri() ) )")
     Playlist toPlaylist(PlaylistEntity playlistEntity);
 
     @Mapping(target = "publicId", source = "id")
     @Mapping(target = "playlistName", source = "name")
     @Mapping(target = "playlistDescription", source = "description")
     @Mapping(target = "id", ignore = true)
+    @Mapping(target = "contextUri", ignore = true)
     PlaylistEntity toPlaylistEntity(Playlist playlist);
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverter.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverter.java
@@ -2,23 +2,19 @@ package com.odeyalo.sonata.playlists.support.converter;
 
 import com.odeyalo.sonata.playlists.dto.PlaylistDto;
 import com.odeyalo.sonata.playlists.model.Playlist;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 
 /**
  * Converter for PlaylistDto
  */
-@Mapper(uses = {PlaylistOwnerConverter.class, ImagesDtoConverter.class}, componentModel = "spring")
+@Mapper(uses = {
+        PlaylistOwnerConverter.class,
+        ImagesDtoConverter.class
+}, componentModel = "spring")
 public interface PlaylistDtoConverter {
 
     @Mapping(target = "owner", source = "playlistOwner")
-    @Mapping(target = "contextUri", ignore = true)
+    @Mapping(target = "contextUri", expression = "java( \"sonata:playlist:\" + playlist.getId() )")
     PlaylistDto toPlaylistDto(Playlist playlist);
-
-    @AfterMapping
-    default void enhanceContextUri(@MappingTarget PlaylistDto.PlaylistDtoBuilder builder, Playlist playlist) {
-        builder.contextUri("sonata:playlist:" + playlist.getId());
-    }
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverter.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverter.java
@@ -2,8 +2,10 @@ package com.odeyalo.sonata.playlists.support.converter;
 
 import com.odeyalo.sonata.playlists.dto.PlaylistDto;
 import com.odeyalo.sonata.playlists.model.Playlist;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 /**
  * Converter for PlaylistDto
@@ -14,4 +16,8 @@ public interface PlaylistDtoConverter {
     @Mapping(target = "owner", source = "playlistOwner")
     PlaylistDto toPlaylistDto(Playlist playlist);
 
+    @AfterMapping
+    default void enhanceContextUri(@MappingTarget PlaylistDto.PlaylistDtoBuilder builder, Playlist playlist) {
+        builder.contextUri("sonata:playlist:" + playlist.getId());
+    }
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverter.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverter.java
@@ -14,6 +14,7 @@ import org.mapstruct.MappingTarget;
 public interface PlaylistDtoConverter {
 
     @Mapping(target = "owner", source = "playlistOwner")
+    @Mapping(target = "contextUri", ignore = true)
     PlaylistDto toPlaylistDto(Playlist playlist);
 
     @AfterMapping

--- a/src/main/resources/db/migration/V11__add_playlist_context_uri.sql
+++ b/src/main/resources/db/migration/V11__add_playlist_context_uri.sql
@@ -1,0 +1,5 @@
+ALTER TABLE playlists ADD COLUMN context_uri varchar(50) UNIQUE;
+
+UPDATE playlists SET context_uri=CONCAT('sonata:playlist:', public_id);
+
+ALTER TABLE playlists ALTER COLUMN context_uri SET NOT NULL

--- a/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistEndpointTest.java
@@ -119,6 +119,15 @@ public class FetchPlaylistEndpointTest {
         }
 
         @Test
+        void shouldReturnPlaylistContextUri() {
+            WebTestClient.ResponseSpec responseSpec = prepareAndSend();
+
+            PlaylistDto body = responseSpec.expectBody(PlaylistDto.class).returnResult().getResponseBody();
+
+            PlaylistDtoAssert.forPlaylist(body).contextUri().isEqualTo("sonata:playlist:" + existingPlaylist.getId());
+        }
+
+        @Test
         void shouldReturnPlaylistType() {
             WebTestClient.ResponseSpec responseSpec = prepareAndSend();
 

--- a/src/test/java/com/odeyalo/sonata/playlists/repository/r2dbc/R2dbcPlaylistRepositoryTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/repository/r2dbc/R2dbcPlaylistRepositoryTest.java
@@ -86,6 +86,16 @@ class R2dbcPlaylistRepositoryTest {
     }
 
     @Test
+    void shouldGenerateContextUriForPlaylist() {
+        Playlist playlist = PlaylistFaker.createWithNoId().get();
+
+        r2dbcPlaylistRepository.save(playlist)
+                .as(StepVerifier::create)
+                .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId()))
+                .verifyComplete();
+    }
+
+    @Test
     void shouldSaveThePlaylistNameAsProvided() {
         Playlist saved = createAndSavePlaylist();
 

--- a/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistOperationsTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistOperationsTest.java
@@ -1,0 +1,39 @@
+package com.odeyalo.sonata.playlists.service;
+
+import com.odeyalo.sonata.playlists.model.Playlist;
+import com.odeyalo.sonata.playlists.model.PlaylistOwner;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+import testing.factory.PlaylistOperationsTestableFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultPlaylistOperationsTest {
+
+    @Test
+    void shouldGenerateContextUriForPlaylist() {
+        final var testable = PlaylistOperationsTestableFactory.create();
+        final var playlistInfo = CreatePlaylistInfo.builder().name("My name").build();
+        final var owner = PlaylistOwner.builder().id("123").displayName("odeyalo").build();
+
+        testable.createPlaylist(playlistInfo, owner)
+                .as(StepVerifier::create)
+                .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId()))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldSaveContextUriForPlaylist() {
+        final var testable = PlaylistOperationsTestableFactory.create();
+        final var playlistInfo = CreatePlaylistInfo.builder().name("My name").build();
+        final var owner = PlaylistOwner.builder().id("123").displayName("odeyalo").build();
+
+        Playlist createdPlaylist = testable.createPlaylist(playlistInfo, owner).block();
+
+        //noinspection DataFlowIssue
+        testable.findById(createdPlaylist.getId())
+                .as(StepVerifier::create)
+                .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId()))
+                .verifyComplete();
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/playlists/service/SecurityPolicyPlaylistOperationsFacadeTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/SecurityPolicyPlaylistOperationsFacadeTest.java
@@ -5,8 +5,6 @@ import com.odeyalo.sonata.playlists.exception.PlaylistOperationNotAllowedExcepti
 import com.odeyalo.sonata.playlists.model.EntityType;
 import com.odeyalo.sonata.playlists.model.Playlist;
 import com.odeyalo.sonata.playlists.model.User;
-import com.odeyalo.sonata.playlists.repository.InMemoryPlaylistRepository;
-import com.odeyalo.sonata.playlists.service.upload.MockImageUploader;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,6 +14,7 @@ import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import testing.factory.PlaylistOperationsTestableFactory;
 import testing.faker.PlaylistFaker;
 import testing.spring.web.FilePartStub;
 
@@ -284,16 +283,9 @@ class SecurityPolicyPlaylistOperationsFacadeTest {
 
         public SecurityPolicyPlaylistOperationsFacade build() {
             return new SecurityPolicyPlaylistOperationsFacade(
-                    TestingPlaylistOperations.withPlaylists(playlists)
+                    PlaylistOperationsTestableFactory.withPlaylists(playlists)
             );
         }
     }
 
-    public static class TestingPlaylistOperations {
-
-        public static PlaylistOperations withPlaylists(List<Playlist> playlists) {
-            final InMemoryPlaylistRepository repository = new InMemoryPlaylistRepository(playlists);
-            return new DefaultPlaylistOperations(repository, new MockImageUploader());
-        }
-    }
 }

--- a/src/test/java/testing/asserts/ContextUriAssert.java
+++ b/src/test/java/testing/asserts/ContextUriAssert.java
@@ -1,0 +1,10 @@
+package testing.asserts;
+
+import org.assertj.core.api.AbstractAssert;
+
+public final class ContextUriAssert extends AbstractAssert<ContextUriAssert, String> {
+
+    public ContextUriAssert(final String contextUri) {
+        super(contextUri, ContextUriAssert.class);
+    }
+}

--- a/src/test/java/testing/asserts/PlaylistDtoAssert.java
+++ b/src/test/java/testing/asserts/PlaylistDtoAssert.java
@@ -4,8 +4,6 @@ import com.odeyalo.sonata.playlists.dto.PlaylistDto;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.StringAssert;
 
-import java.lang.constant.ClassDesc;
-
 /**
  * Asserts for PlaylistDto class
  */
@@ -49,5 +47,9 @@ public class PlaylistDtoAssert extends AbstractAssert<PlaylistDtoAssert, Playlis
 
     public PlaylistOwnerDtoAssert owner() {
         return new PlaylistOwnerDtoAssert(actual.getOwner());
+    }
+
+    public ContextUriAssert contextUri() {
+        return new ContextUriAssert(actual.getContextUri());
     }
 }

--- a/src/test/java/testing/factory/PlaylistOperationsTestableFactory.java
+++ b/src/test/java/testing/factory/PlaylistOperationsTestableFactory.java
@@ -1,0 +1,22 @@
+package testing.factory;
+
+import com.odeyalo.sonata.playlists.model.Playlist;
+import com.odeyalo.sonata.playlists.repository.InMemoryPlaylistRepository;
+import com.odeyalo.sonata.playlists.service.DefaultPlaylistOperations;
+import com.odeyalo.sonata.playlists.service.PlaylistOperations;
+import com.odeyalo.sonata.playlists.service.upload.MockImageUploader;
+
+import java.util.List;
+
+public class PlaylistOperationsTestableFactory {
+
+    public static PlaylistOperations withPlaylists(List<Playlist> playlists) {
+        final InMemoryPlaylistRepository repository = new InMemoryPlaylistRepository(playlists);
+        return new DefaultPlaylistOperations(repository, new MockImageUploader());
+    }
+
+    public static DefaultPlaylistOperations create() {
+        final InMemoryPlaylistRepository repository = new InMemoryPlaylistRepository();
+        return new DefaultPlaylistOperations(repository, new MockImageUploader());
+    }
+}

--- a/src/test/java/testing/faker/PlaylistEntityFaker.java
+++ b/src/test/java/testing/faker/PlaylistEntityFaker.java
@@ -11,12 +11,14 @@ public class PlaylistEntityFaker {
     private final Faker faker = Faker.instance();
 
     public PlaylistEntityFaker() {
+        String publicId = RandomStringUtils.randomAlphanumeric(22);
         builder
                 .id(faker.random().nextLong())
                 .playlistName(faker.music().instrument())
                 .playlistDescription(faker.weather().description())
                 .playlistType(faker.options().option(PlaylistType.class))
-                .publicId(RandomStringUtils.randomAlphanumeric(22))
+                .publicId(publicId)
+                .contextUri("sonata:playlist:" + publicId)
                 .playlistOwner(PlaylistOwnerEntityFaker.create().get())
                 .build();
     }
@@ -41,6 +43,7 @@ public class PlaylistEntityFaker {
 
     public PlaylistEntityFaker setPublicId(String publicId) {
         builder.publicId(publicId);
+        builder.contextUri("sonata:playlist:" + publicId);
         return this;
     }
 


### PR DESCRIPTION
Now every playlist contains a context uri in format: 'sonata:playlist:ID' where ID is equal to  playlist ID.

Added migrations for existing playlists

Now response for GET /playlist includes context_uri 

Implementation of #51 