### PR TITLE
Made refactoring of PlaylistService

### DIFF
--- a/src/main/java/com/odeyalo/sonata/playlists/config/factory/FactoryConfiguration.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/config/factory/FactoryConfiguration.java
@@ -1,5 +1,6 @@
 package com.odeyalo.sonata.playlists.config.factory;
 
+import com.odeyalo.sonata.playlists.entity.factory.*;
 import com.odeyalo.sonata.playlists.model.Playlist;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,5 +11,26 @@ public class FactoryConfiguration {
     @Bean
     public Playlist.Factory playlistFactory() {
         return new Playlist.Factory();
+    }
+
+
+    @Bean
+    public PlaylistEntityFactory playlistEntityFactory() {
+        return new DefaultPlaylistEntityFactory(imagesEntityFactory(), playlistOwnerEntityFactory());
+    }
+
+    @Bean
+    public ImagesEntityFactory imagesEntityFactory() {
+        return new DefaultImagesEntityFactory(imageEntityFactory());
+    }
+
+    @Bean
+    public PlaylistOwnerEntityFactory playlistOwnerEntityFactory() {
+        return new PlaylistOwnerEntityFactory();
+    }
+
+    @Bean
+    public ImageEntityFactory imageEntityFactory() {
+        return new ImageEntityFactory();
     }
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/config/factory/FactoryConfiguration.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/config/factory/FactoryConfiguration.java
@@ -1,0 +1,14 @@
+package com.odeyalo.sonata.playlists.config.factory;
+
+import com.odeyalo.sonata.playlists.model.Playlist;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FactoryConfiguration {
+
+    @Bean
+    public Playlist.Factory playlistFactory() {
+        return new Playlist.Factory();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/playlists/entity/PlaylistEntity.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/PlaylistEntity.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class PlaylistEntity implements Persistable<Long> {
     @Id
     @Column("playlist_id")
+    @With
     Long id;
     String publicId;
     String playlistName;

--- a/src/main/java/com/odeyalo/sonata/playlists/entity/factory/DefaultImagesEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/factory/DefaultImagesEntityFactory.java
@@ -1,0 +1,24 @@
+package com.odeyalo.sonata.playlists.entity.factory;
+
+import com.odeyalo.sonata.playlists.entity.ImageEntity;
+import com.odeyalo.sonata.playlists.entity.ImagesEntity;
+import com.odeyalo.sonata.playlists.model.Images;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public final class DefaultImagesEntityFactory implements ImagesEntityFactory {
+    private final ImageEntityFactory imageFactory;
+
+    public DefaultImagesEntityFactory(final ImageEntityFactory imageFactory) {
+        this.imageFactory = imageFactory;
+    }
+
+    @Override
+    @NotNull
+    public ImagesEntity create(@NotNull final Images images) {
+        final List<ImageEntity> imageEntities = images.stream().map(imageFactory::create).toList();
+
+        return ImagesEntity.of(imageEntities);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/playlists/entity/factory/DefaultPlaylistEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/factory/DefaultPlaylistEntityFactory.java
@@ -21,7 +21,7 @@ public final class DefaultPlaylistEntityFactory implements PlaylistEntityFactory
         final PlaylistEntityBuilder builder = PlaylistEntity.builder();
 
         return builder
-                .publicId(playlist.getId())
+                .publicId(playlist.getId().value())
                 .playlistName(playlist.getName())
                 .playlistDescription(playlist.getDescription())
                 .playlistType(playlist.getPlaylistType())

--- a/src/main/java/com/odeyalo/sonata/playlists/entity/factory/DefaultPlaylistEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/factory/DefaultPlaylistEntityFactory.java
@@ -1,0 +1,33 @@
+package com.odeyalo.sonata.playlists.entity.factory;
+
+import com.odeyalo.sonata.playlists.entity.PlaylistEntity;
+import com.odeyalo.sonata.playlists.entity.PlaylistEntity.PlaylistEntityBuilder;
+import com.odeyalo.sonata.playlists.model.Playlist;
+import org.jetbrains.annotations.NotNull;
+
+public final class DefaultPlaylistEntityFactory implements PlaylistEntityFactory {
+    private final ImagesEntityFactory imagesFactory;
+    private final PlaylistOwnerEntityFactory playlistOwnerFactory;
+
+    public DefaultPlaylistEntityFactory(final ImagesEntityFactory imagesFactory,
+                                        final PlaylistOwnerEntityFactory playlistOwnerFactory) {
+        this.imagesFactory = imagesFactory;
+        this.playlistOwnerFactory = playlistOwnerFactory;
+    }
+
+    @Override
+    @NotNull
+    public PlaylistEntity create(@NotNull final Playlist playlist) {
+        final PlaylistEntityBuilder builder = PlaylistEntity.builder();
+
+        return builder
+                .publicId(playlist.getId())
+                .playlistName(playlist.getName())
+                .playlistDescription(playlist.getDescription())
+                .playlistType(playlist.getPlaylistType())
+                .images(imagesFactory.create(playlist.getImages()).getImages())
+                .playlistOwner(playlistOwnerFactory.create(playlist.getPlaylistOwner()))
+                .contextUri(playlist.getContextUri().asString())
+                .build();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/playlists/entity/factory/ImageEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/factory/ImageEntityFactory.java
@@ -1,0 +1,18 @@
+package com.odeyalo.sonata.playlists.entity.factory;
+
+import com.odeyalo.sonata.playlists.entity.ImageEntity;
+import com.odeyalo.sonata.playlists.model.Image;
+import org.jetbrains.annotations.NotNull;
+
+public final class ImageEntityFactory {
+
+    @NotNull
+    public ImageEntity create(@NotNull Image image) {
+        return ImageEntity.builder()
+                .url(image.getUrl())
+                .width(image.getWidth())
+                .height(image.getHeight())
+                .build();
+    }
+
+}

--- a/src/main/java/com/odeyalo/sonata/playlists/entity/factory/ImagesEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/factory/ImagesEntityFactory.java
@@ -1,0 +1,12 @@
+package com.odeyalo.sonata.playlists.entity.factory;
+
+import com.odeyalo.sonata.playlists.entity.ImagesEntity;
+import com.odeyalo.sonata.playlists.model.Images;
+import org.jetbrains.annotations.NotNull;
+
+public interface ImagesEntityFactory {
+
+    @NotNull
+    ImagesEntity create(@NotNull Images images);
+
+}

--- a/src/main/java/com/odeyalo/sonata/playlists/entity/factory/PlaylistEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/factory/PlaylistEntityFactory.java
@@ -1,0 +1,12 @@
+package com.odeyalo.sonata.playlists.entity.factory;
+
+import com.odeyalo.sonata.playlists.entity.PlaylistEntity;
+import com.odeyalo.sonata.playlists.model.Playlist;
+import org.jetbrains.annotations.NotNull;
+
+public interface PlaylistEntityFactory {
+
+    @NotNull
+    PlaylistEntity create(@NotNull Playlist playlist);
+
+}

--- a/src/main/java/com/odeyalo/sonata/playlists/entity/factory/PlaylistOwnerEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/entity/factory/PlaylistOwnerEntityFactory.java
@@ -1,0 +1,17 @@
+package com.odeyalo.sonata.playlists.entity.factory;
+
+import com.odeyalo.sonata.playlists.entity.PlaylistOwnerEntity;
+import com.odeyalo.sonata.playlists.model.PlaylistOwner;
+import org.jetbrains.annotations.NotNull;
+
+public final class PlaylistOwnerEntityFactory {
+
+    @NotNull
+    public PlaylistOwnerEntity create(@NotNull PlaylistOwner owner) {
+        return PlaylistOwnerEntity.builder()
+                .publicId(owner.getId())
+                .displayName(owner.getDisplayName())
+                .entityType(owner.getEntityType())
+                .build();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/playlists/model/Playlist.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/model/Playlist.java
@@ -20,6 +20,7 @@ import static com.odeyalo.sonata.playlists.model.PlaylistType.PUBLIC;
 @AllArgsConstructor(staticName = "of")
 @Builder(toBuilder = true)
 public class Playlist {
+    @NotNull
     String id;
     String name;
     String description;

--- a/src/main/java/com/odeyalo/sonata/playlists/model/Playlist.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/model/Playlist.java
@@ -5,7 +5,6 @@ import com.odeyalo.sonata.playlists.service.CreatePlaylistInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -21,7 +20,7 @@ import static com.odeyalo.sonata.playlists.model.PlaylistType.PUBLIC;
 @Builder(toBuilder = true)
 public class Playlist {
     @NotNull
-    String id;
+    PlaylistId id;
     String name;
     String description;
     ContextUri contextUri;
@@ -59,14 +58,15 @@ public class Playlist {
         @NotNull
         public Playlist create(@NotNull final CreatePlaylistInfo playlistInfo,
                                @NotNull final PlaylistOwner owner) {
-            final String id = RandomStringUtils.randomAlphanumeric(22);
+
+            final PlaylistId id = PlaylistId.random();
 
             return Playlist.builder()
                     .id(id)
                     .name(playlistInfo.getName())
                     .description(playlistInfo.getDescription())
                     .playlistType(playlistInfo.getPlaylistType())
-                    .contextUri(ContextUri.forPlaylist(id))
+                    .contextUri(id.asContextUri())
                     .playlistOwner(owner)
                     .build();
         }

--- a/src/main/java/com/odeyalo/sonata/playlists/model/Playlist.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/model/Playlist.java
@@ -1,9 +1,12 @@
 package com.odeyalo.sonata.playlists.model;
 
 import com.odeyalo.sonata.common.context.ContextUri;
+import com.odeyalo.sonata.playlists.service.CreatePlaylistInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
@@ -15,7 +18,7 @@ import static com.odeyalo.sonata.playlists.model.PlaylistType.PUBLIC;
  */
 @Value
 @AllArgsConstructor(staticName = "of")
-@Builder
+@Builder(toBuilder = true)
 public class Playlist {
     String id;
     String name;
@@ -29,24 +32,18 @@ public class Playlist {
     @Builder.Default
     EntityType type = PLAYLIST;
 
-    public static PlaylistBuilder from(Playlist playlist) {
-        return builder()
-                .id(playlist.getId())
-                .name(playlist.getName())
-                .description(playlist.getDescription())
-                .playlistType(playlist.getPlaylistType())
-                .images(playlist.getImages())
-                .playlistOwner(playlist.getPlaylistOwner())
-                .type(playlist.getType());
+    @NotNull
+    public static PlaylistBuilder from(@NotNull final Playlist playlist) {
+        return playlist.toBuilder();
     }
 
-    public boolean isWritePermissionGrantedFor(final User authorizedUser) {
+    public boolean isWritePermissionGrantedFor(@NotNull final User authorizedUser) {
         return Objects.equals(
                 playlistOwner.getId(), authorizedUser.getId()
         );
     }
 
-    public boolean isReadPermissionGrantedFor(final User authorizedUser) {
+    public boolean isReadPermissionGrantedFor(@NotNull final User authorizedUser) {
         return isPublicPlaylist() || Objects.equals(
                 playlistOwner.getId(), authorizedUser.getId()
         );
@@ -54,5 +51,23 @@ public class Playlist {
 
     private boolean isPublicPlaylist() {
         return playlistType == PUBLIC;
+    }
+
+    public static class Factory {
+
+        @NotNull
+        public Playlist create(@NotNull final CreatePlaylistInfo playlistInfo,
+                               @NotNull final PlaylistOwner owner) {
+            final String id = RandomStringUtils.randomAlphanumeric(22);
+
+            return Playlist.builder()
+                    .id(id)
+                    .name(playlistInfo.getName())
+                    .description(playlistInfo.getDescription())
+                    .playlistType(playlistInfo.getPlaylistType())
+                    .contextUri(ContextUri.forPlaylist(id))
+                    .playlistOwner(owner)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/model/PlaylistId.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/model/PlaylistId.java
@@ -1,0 +1,30 @@
+package com.odeyalo.sonata.playlists.model;
+
+import com.odeyalo.sonata.common.context.ContextUri;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.jetbrains.annotations.NotNull;
+
+public record PlaylistId(@NotNull String value) {
+
+    @NotNull
+    public static PlaylistId of(@NotNull final String value) {
+        return new PlaylistId(value);
+    }
+
+    /**
+     * Generate a pseudo-random {@link PlaylistId}.
+     * Can produce already exist ID, these cases should be handled
+     * @return - a pseudo-random {@link PlaylistId}
+     */
+    @NotNull
+    public static PlaylistId random() {
+        return new PlaylistId(
+                RandomStringUtils.randomAlphanumeric(22)
+        );
+    }
+
+    @NotNull
+    public ContextUri asContextUri() {
+        return ContextUri.forPlaylist(value);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/playlists/service/CreatePlaylistInfo.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/CreatePlaylistInfo.java
@@ -3,7 +3,6 @@ package com.odeyalo.sonata.playlists.service;
 import com.odeyalo.sonata.playlists.model.PlaylistType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.NonNull;
 import lombok.Value;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -16,12 +15,15 @@ import org.jetbrains.annotations.Nullable;
 @Builder
 public class CreatePlaylistInfo {
     @NotNull
-    @NonNull
     String name;
     @Nullable
     String description;
     @NotNull
-    @NonNull
     @Builder.Default
     PlaylistType playlistType = PlaylistType.PRIVATE;
+
+    @NotNull
+    public static CreatePlaylistInfo withName(@NotNull final String name) {
+        return builder().name(name).build();
+    }
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistOperations.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistOperations.java
@@ -35,8 +35,7 @@ public final class DefaultPlaylistOperations implements PlaylistOperations {
     @Override
     @NotNull
     public Mono<Playlist> createPlaylist(CreatePlaylistInfo playlistInfo, PlaylistOwner playlistOwner) {
-        final Playlist playlist = toPlaylist(playlistInfo, playlistOwner);
-        return playlistService.save(playlist);
+        return playlistService.create(playlistInfo, playlistOwner);
     }
 
     @Override
@@ -54,7 +53,7 @@ public final class DefaultPlaylistOperations implements PlaylistOperations {
 
         return playlistService.loadPlaylist(targetPlaylist)
                 .map(playlist -> partialPlaylistUpdate(updateInfo, playlist))
-                .flatMap(playlistService::save);
+                .flatMap(playlistService::update);
     }
 
     @NotNull
@@ -63,7 +62,7 @@ public final class DefaultPlaylistOperations implements PlaylistOperations {
         Image image = tuple.getT2();
 
         Playlist updatedPlaylist = Playlist.from(playlist).images(Images.single(image)).build();
-        return playlistService.save(updatedPlaylist);
+        return playlistService.update(updatedPlaylist);
     }
 
     private static Playlist partialPlaylistUpdate(PartialPlaylistDetailsUpdateInfo updateInfo, Playlist playlist) {
@@ -81,14 +80,5 @@ public final class DefaultPlaylistOperations implements PlaylistOperations {
             builder.playlistType(updateInfo.getPlaylistType());
         }
         return builder.build();
-    }
-
-    private static Playlist toPlaylist(CreatePlaylistInfo playlistInfo, PlaylistOwner playlistOwner) {
-        return Playlist.builder()
-                .name(playlistInfo.getName())
-                .description(playlistInfo.getDescription())
-                .playlistType(playlistInfo.getPlaylistType())
-                .playlistOwner(playlistOwner)
-                .build();
     }
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
@@ -1,6 +1,7 @@
 package com.odeyalo.sonata.playlists.service;
 
 import com.odeyalo.sonata.playlists.entity.PlaylistEntity;
+import com.odeyalo.sonata.playlists.entity.factory.PlaylistEntityFactory;
 import com.odeyalo.sonata.playlists.model.Playlist;
 import com.odeyalo.sonata.playlists.model.PlaylistOwner;
 import com.odeyalo.sonata.playlists.repository.PlaylistRepository;
@@ -14,13 +15,16 @@ public final class DefaultPlaylistService implements PlaylistService {
     private final PlaylistRepository playlistRepository;
     private final PlaylistConverter playlistConverter;
     private final Playlist.Factory playlistFactory;
+    private final PlaylistEntityFactory playlistEntityFactory;
 
     public DefaultPlaylistService(final PlaylistRepository playlistRepository,
                                   final PlaylistConverter playlistConverter,
-                                  final Playlist.Factory playlistFactory) {
+                                  final Playlist.Factory playlistFactory,
+                                  final PlaylistEntityFactory playlistEntityFactory) {
         this.playlistRepository = playlistRepository;
         this.playlistConverter = playlistConverter;
         this.playlistFactory = playlistFactory;
+        this.playlistEntityFactory = playlistEntityFactory;
     }
 
     @Override
@@ -30,10 +34,10 @@ public final class DefaultPlaylistService implements PlaylistService {
 
         final Playlist playlist = playlistFactory.create(playlistInfo, owner);
 
-        final PlaylistEntity playlistEntity = playlistConverter.toPlaylistEntity(playlist);
+        final PlaylistEntity playlistEntity = playlistEntityFactory.create(playlist);
 
         return playlistRepository.save(playlistEntity)
-                .map(playlistConverter::toPlaylist);
+                .map(it -> playlist);
     }
 
     @Override
@@ -63,9 +67,10 @@ public final class DefaultPlaylistService implements PlaylistService {
     }
 
     @NotNull
-    private Mono<PlaylistEntity> updatePlaylistEntity(Playlist playlist, PlaylistEntity parent) {
+    private Mono<PlaylistEntity> updatePlaylistEntity(@NotNull final Playlist playlist,
+                                                      @NotNull final PlaylistEntity parent) {
 
-        PlaylistEntity entity = playlistConverter.toPlaylistEntity(playlist);
+        PlaylistEntity entity = playlistEntityFactory.create(playlist);
         entity.setId(parent.getId());
         entity.setContextUri("sonata:playlist:" + entity.getPublicId());
 

--- a/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
@@ -25,16 +25,6 @@ public final class DefaultPlaylistService implements PlaylistService {
 
     @Override
     @NotNull
-    public Mono<Playlist> save(@NotNull final Playlist playlist) {
-        if ( playlist.getId() == null ) {
-            return savePlaylist(playlist);
-        }
-
-        return updatePlaylist(playlist);
-    }
-
-    @Override
-    @NotNull
     public Mono<Playlist> create(@NotNull final CreatePlaylistInfo playlistInfo,
                                  @NotNull final PlaylistOwner owner) {
 
@@ -61,14 +51,6 @@ public final class DefaultPlaylistService implements PlaylistService {
     @NotNull
     public Mono<Playlist> update(@NotNull final Playlist playlist) {
         return updatePlaylist(playlist);
-    }
-
-    @NotNull
-    private Mono<Playlist> savePlaylist(Playlist playlist) {
-        PlaylistEntity toSave = createPlaylistEntity(playlist);
-
-        return playlistRepository.save(toSave)
-                .map(playlistConverter::toPlaylist);
     }
 
     @NotNull
@@ -101,13 +83,4 @@ public final class DefaultPlaylistService implements PlaylistService {
         return playlistRepository.save(entity);
     }
 
-    @NotNull
-    private PlaylistEntity createPlaylistEntity(Playlist playlist) {
-        String playlistId = playlist.getId() != null ? playlist.getId() : RandomStringUtils.randomAlphanumeric(22);
-        PlaylistEntity entity = playlistConverter.toPlaylistEntity(playlist);
-        entity.setPublicId(playlistId);
-        entity.setContextUri("sonata:playlist:" + playlistId);
-
-        return entity;
-    }
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
@@ -28,10 +28,12 @@ public final class DefaultPlaylistService implements PlaylistService {
         }
 
         return updatePlaylist(playlist);
+}
 
-//        PlaylistEntity playlistEntity = playlistConverter.toPlaylistEntity(playlist);
-//        return playlistRepository.save(playlistEntity)
-//                .map(playlistConverter::toPlaylist);
+    @Override
+    @NotNull
+    public Mono<Playlist> update(@NotNull final Playlist playlist) {
+        return updatePlaylist(playlist);
     }
 
     @NotNull

--- a/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
@@ -48,7 +48,7 @@ public final class DefaultPlaylistService implements PlaylistService {
 
     @NotNull
     private Mono<Playlist> updatePlaylist(Playlist playlist) {
-        return playlistRepository.findByPublicId(playlist.getId())
+        return playlistRepository.findByPublicId(playlist.getId().value())
                 .flatMap(originalPlaylist -> updatePlaylistEntity(originalPlaylist, playlist))
                 .map(playlistConverter::toPlaylist);
     }

--- a/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
@@ -1,7 +1,10 @@
 package com.odeyalo.sonata.playlists.service;
 
+import com.odeyalo.sonata.common.context.ContextUri;
 import com.odeyalo.sonata.playlists.entity.PlaylistEntity;
+import com.odeyalo.sonata.playlists.entity.PlaylistOwnerEntity;
 import com.odeyalo.sonata.playlists.model.Playlist;
+import com.odeyalo.sonata.playlists.model.PlaylistOwner;
 import com.odeyalo.sonata.playlists.repository.PlaylistRepository;
 import com.odeyalo.sonata.playlists.support.converter.PlaylistConverter;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -28,7 +31,31 @@ public final class DefaultPlaylistService implements PlaylistService {
         }
 
         return updatePlaylist(playlist);
-}
+    }
+
+    @Override
+    @NotNull
+    public Mono<Playlist> create(@NotNull final CreatePlaylistInfo playlistInfo,
+                                 @NotNull final PlaylistOwner owner) {
+
+        final String id = RandomStringUtils.randomAlphanumeric(22);
+
+        final PlaylistEntity entity = PlaylistEntity.builder()
+                .publicId(id)
+                .playlistName(playlistInfo.getName())
+                .playlistDescription(playlistInfo.getDescription())
+                .playlistType(playlistInfo.getPlaylistType())
+                .contextUri(ContextUri.forPlaylist(id).asString())
+                .playlistOwner(PlaylistOwnerEntity.builder()
+                        .publicId(owner.getId())
+                        .displayName(owner.getDisplayName())
+                        .entityType(owner.getEntityType())
+                        .build())
+                .build();
+
+        return playlistRepository.save(entity)
+                .map(playlistConverter::toPlaylist);
+    }
 
     @Override
     @NotNull

--- a/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistService.java
@@ -49,7 +49,7 @@ public final class DefaultPlaylistService implements PlaylistService {
     @NotNull
     private Mono<Playlist> updatePlaylist(Playlist playlist) {
         return playlistRepository.findByPublicId(playlist.getId())
-                .flatMap(parent -> updatePlaylistEntity(playlist, parent))
+                .flatMap(originalPlaylist -> updatePlaylistEntity(originalPlaylist, playlist))
                 .map(playlistConverter::toPlaylist);
     }
 
@@ -60,21 +60,14 @@ public final class DefaultPlaylistService implements PlaylistService {
                 .map(playlistConverter::toPlaylist);
     }
 
-    @Override
     @NotNull
-    public Mono<Playlist> loadPlaylist(@NotNull final TargetPlaylist targetPlaylist) {
-        return loadPlaylist(targetPlaylist.getPlaylistId());
+    private Mono<PlaylistEntity> updatePlaylistEntity(@NotNull final PlaylistEntity originalPlaylist,
+                                                      @NotNull final Playlist playlist) {
+
+        final PlaylistEntity updatedPlaylist = playlistEntityFactory.create(playlist);
+
+        return playlistRepository.save(
+                updatedPlaylist.withId(originalPlaylist.getId())
+        );
     }
-
-    @NotNull
-    private Mono<PlaylistEntity> updatePlaylistEntity(@NotNull final Playlist playlist,
-                                                      @NotNull final PlaylistEntity parent) {
-
-        PlaylistEntity entity = playlistEntityFactory.create(playlist);
-        entity.setId(parent.getId());
-        entity.setContextUri("sonata:playlist:" + entity.getPublicId());
-
-        return playlistRepository.save(entity);
-    }
-
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/service/InMemoryPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/InMemoryPlaylistService.java
@@ -1,9 +1,8 @@
 package com.odeyalo.sonata.playlists.service;
 
-import com.odeyalo.sonata.common.context.ContextUri;
 import com.odeyalo.sonata.playlists.model.Playlist;
+import com.odeyalo.sonata.playlists.model.PlaylistId;
 import com.odeyalo.sonata.playlists.model.PlaylistOwner;
-import org.apache.commons.lang.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 
@@ -14,11 +13,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public final class InMemoryPlaylistService implements PlaylistService {
-    private final Map<String, Playlist> playlists;
+    private final Map<PlaylistId, Playlist> playlists;
 
     public InMemoryPlaylistService(List<Playlist> cache) {
 
-        Map<String, Playlist> items = cache.stream()
+        Map<PlaylistId, Playlist> items = cache.stream()
                 .collect(
                         Collectors.toMap(Playlist::getId, Function.identity())
                 );
@@ -55,27 +54,14 @@ public final class InMemoryPlaylistService implements PlaylistService {
     @NotNull
     public Mono<Playlist> loadPlaylist(@NotNull final String id) {
         return Mono.justOrEmpty(
-                playlists.get(id)
+                playlists.get(PlaylistId.of(id))
         );
     }
 
     private Playlist doSave(Playlist playlist) {
-        Playlist withId = updateWithIdOrNothing(playlist);
-        playlists.put(withId.getId(), withId);
-        return withId;
-    }
-
-    private Playlist updateWithIdOrNothing(Playlist playlist) {
-        String id = playlist.getId();
-
-        if ( id == null ) {
-            id = RandomStringUtils.randomAlphanumeric(15);
-            playlist = Playlist.from(playlist).id(id).contextUri(ContextUri.forPlaylist(id)).build();
-        }
-
+        playlists.put(playlist.getId(), playlist);
         return playlist;
     }
-
 
     private static Playlist toPlaylist(CreatePlaylistInfo playlistInfo, PlaylistOwner playlistOwner) {
         return Playlist.builder()

--- a/src/main/java/com/odeyalo/sonata/playlists/service/InMemoryPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/InMemoryPlaylistService.java
@@ -2,6 +2,7 @@ package com.odeyalo.sonata.playlists.service;
 
 import com.odeyalo.sonata.common.context.ContextUri;
 import com.odeyalo.sonata.playlists.model.Playlist;
+import com.odeyalo.sonata.playlists.model.PlaylistOwner;
 import org.apache.commons.lang.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
@@ -42,6 +43,16 @@ public final class InMemoryPlaylistService implements PlaylistService {
 
     @Override
     @NotNull
+    public Mono<Playlist> create(@NotNull final CreatePlaylistInfo playlistInfo,
+                                 @NotNull final PlaylistOwner owner) {
+
+        final Playlist playlist = toPlaylist(playlistInfo, owner);
+
+        return Mono.fromCallable(() -> doSave(playlist));
+    }
+
+    @Override
+    @NotNull
     public Mono<Playlist> update(@NotNull final Playlist playlist) {
         return Mono.fromCallable(() -> doSave(playlist));
     }
@@ -69,5 +80,15 @@ public final class InMemoryPlaylistService implements PlaylistService {
         }
 
         return playlist;
+    }
+
+
+    private static Playlist toPlaylist(CreatePlaylistInfo playlistInfo, PlaylistOwner playlistOwner) {
+        return Playlist.builder()
+                .name(playlistInfo.getName())
+                .description(playlistInfo.getDescription())
+                .playlistType(playlistInfo.getPlaylistType())
+                .playlistOwner(playlistOwner)
+                .build();
     }
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/service/InMemoryPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/InMemoryPlaylistService.java
@@ -37,12 +37,6 @@ public final class InMemoryPlaylistService implements PlaylistService {
 
     @Override
     @NotNull
-    public Mono<Playlist> save(@NotNull final Playlist playlist) {
-        return Mono.fromCallable(() -> doSave(playlist));
-    }
-
-    @Override
-    @NotNull
     public Mono<Playlist> create(@NotNull final CreatePlaylistInfo playlistInfo,
                                  @NotNull final PlaylistOwner owner) {
 

--- a/src/main/java/com/odeyalo/sonata/playlists/service/InMemoryPlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/InMemoryPlaylistService.java
@@ -29,17 +29,26 @@ public final class InMemoryPlaylistService implements PlaylistService {
     }
 
     @Override
-    public @NotNull Mono<Playlist> loadPlaylist(final @NotNull TargetPlaylist targetPlaylist) {
+    @NotNull
+    public Mono<Playlist> loadPlaylist(@NotNull final TargetPlaylist targetPlaylist) {
         return loadPlaylist(targetPlaylist.getPlaylistId());
     }
 
     @Override
-    public @NotNull Mono<Playlist> save(@NotNull final Playlist playlist) {
+    @NotNull
+    public Mono<Playlist> save(@NotNull final Playlist playlist) {
         return Mono.fromCallable(() -> doSave(playlist));
     }
 
     @Override
-    public @NotNull Mono<Playlist> loadPlaylist(@NotNull final String id) {
+    @NotNull
+    public Mono<Playlist> update(@NotNull final Playlist playlist) {
+        return Mono.fromCallable(() -> doSave(playlist));
+    }
+
+    @Override
+    @NotNull
+    public Mono<Playlist> loadPlaylist(@NotNull final String id) {
         return Mono.justOrEmpty(
                 playlists.get(id)
         );

--- a/src/main/java/com/odeyalo/sonata/playlists/service/PlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/PlaylistService.java
@@ -14,6 +14,14 @@ public interface PlaylistService extends PlaylistLoader {
     @NotNull
     Mono<Playlist> save(@NotNull Playlist playlist);
 
+    /**
+     * Update existing playlist with new values
+     * @param playlist - existing playlist with new values
+     * @return - a {@link Mono} with {@link Playlist}
+     */
+    @NotNull
+    Mono<Playlist> update(@NotNull Playlist playlist);
+
     @NotNull
     Mono<Playlist> loadPlaylist(@NotNull String id);
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/service/PlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/PlaylistService.java
@@ -12,9 +12,6 @@ import reactor.core.publisher.Mono;
  */
 public interface PlaylistService extends PlaylistLoader {
 
-    @NotNull
-    Mono<Playlist> save(@NotNull Playlist playlist);
-
     /**
      * Create a playlist based on the provided info
      * @param playlistInfo - a basic info about playlist that should be created

--- a/src/main/java/com/odeyalo/sonata/playlists/service/PlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/PlaylistService.java
@@ -33,4 +33,11 @@ public interface PlaylistService extends PlaylistLoader {
 
     @NotNull
     Mono<Playlist> loadPlaylist(@NotNull String id);
+
+    @Override
+    @NotNull
+    default Mono<Playlist> loadPlaylist(@NotNull final TargetPlaylist targetPlaylist) {
+        return loadPlaylist(targetPlaylist.getPlaylistId());
+    }
+
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/service/PlaylistService.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/PlaylistService.java
@@ -1,6 +1,7 @@
 package com.odeyalo.sonata.playlists.service;
 
 import com.odeyalo.sonata.playlists.model.Playlist;
+import com.odeyalo.sonata.playlists.model.PlaylistOwner;
 import com.odeyalo.sonata.playlists.repository.PlaylistRepository;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
@@ -15,7 +16,18 @@ public interface PlaylistService extends PlaylistLoader {
     Mono<Playlist> save(@NotNull Playlist playlist);
 
     /**
+     * Create a playlist based on the provided info
+     * @param playlistInfo - a basic info about playlist that should be created
+     * @param owner - a owner of this playlist
+     * @return - a {@link Mono} with created {@link Playlist}
+     */
+    @NotNull
+    Mono<Playlist> create(@NotNull CreatePlaylistInfo playlistInfo,
+                          @NotNull PlaylistOwner owner);
+
+    /**
      * Update existing playlist with new values
+     *
      * @param playlist - existing playlist with new values
      * @return - a {@link Mono} with {@link Playlist}
      */

--- a/src/main/java/com/odeyalo/sonata/playlists/service/tracks/DefaultPlaylistItemsOperations.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/service/tracks/DefaultPlaylistItemsOperations.java
@@ -51,7 +51,7 @@ public final class DefaultPlaylistItemsOperations implements PlaylistItemsOperat
 
     @NotNull
     private Flux<PlaylistItemEntity> doAddPlaylistItems(@NotNull Playlist playlist, @NotNull AddItemPayload addItemPayload, @NotNull PlaylistCollaborator collaborator) {
-        return itemsRepository.getPlaylistSize(playlist.getId())
+        return itemsRepository.getPlaylistSize(playlist.getId().value())
                 .flatMapMany(playlistSize ->
                         Flux.fromArray(addItemPayload.getUris())
                                 .flatMap(contextUriParser::parse)
@@ -61,7 +61,7 @@ public final class DefaultPlaylistItemsOperations implements PlaylistItemsOperat
                                     final ContextUri contextUri = tuple.getT2();
                                     final int position = (int) (playlistSize + currentIndex);
 
-                                    return saveItem(playlist.getId(), collaborator, contextUri, position);
+                                    return saveItem(playlist.getId().value(), collaborator, contextUri, position);
                                 })
                 );
     }

--- a/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistConverter.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistConverter.java
@@ -25,6 +25,6 @@ public interface PlaylistConverter {
     @Mapping(target = "playlistName", source = "name")
     @Mapping(target = "playlistDescription", source = "description")
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "contextUri", ignore = true)
+    @Mapping(target = "contextUri", expression = "java( playlist.getContextUri().asString() )")
     PlaylistEntity toPlaylistEntity(Playlist playlist);
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistConverter.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistConverter.java
@@ -3,6 +3,7 @@ package com.odeyalo.sonata.playlists.support.converter;
 import com.odeyalo.sonata.common.context.ContextUri;
 import com.odeyalo.sonata.playlists.entity.PlaylistEntity;
 import com.odeyalo.sonata.playlists.model.Playlist;
+import com.odeyalo.sonata.playlists.model.PlaylistId;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -13,13 +14,14 @@ import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
         ImagesEntityConverter.class,
         PlaylistOwnerConverter.class
 }, imports = {
-        ContextUri.class
+        ContextUri.class,
+        PlaylistId.class
 }, injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 public interface PlaylistConverter {
 
-    @Mapping(target = "id", source = "publicId")
+    @Mapping(target = "id", expression = "java( PlaylistId.of( source.getPublicId() ) )")
     @Mapping(target = "name", source = "playlistName")
     @Mapping(target = "description", source = "playlistDescription")
-    @Mapping(target = "contextUri", expression = "java( ContextUri.fromString( playlistEntity.getContextUri() ) )")
-    Playlist toPlaylist(PlaylistEntity playlistEntity);
+    @Mapping(target = "contextUri", expression = "java( ContextUri.fromString( source.getContextUri() ) )")
+    Playlist toPlaylist(PlaylistEntity source);
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistConverter.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistConverter.java
@@ -7,7 +7,9 @@ import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", uses = {
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+@Mapper(componentModel = SPRING, uses = {
         ImagesEntityConverter.class,
         PlaylistOwnerConverter.class
 }, imports = {
@@ -20,11 +22,4 @@ public interface PlaylistConverter {
     @Mapping(target = "description", source = "playlistDescription")
     @Mapping(target = "contextUri", expression = "java( ContextUri.fromString( playlistEntity.getContextUri() ) )")
     Playlist toPlaylist(PlaylistEntity playlistEntity);
-
-    @Mapping(target = "publicId", source = "id")
-    @Mapping(target = "playlistName", source = "name")
-    @Mapping(target = "playlistDescription", source = "description")
-    @Mapping(target = "id", ignore = true)
-    @Mapping(target = "contextUri", expression = "java( playlist.getContextUri().asString() )")
-    PlaylistEntity toPlaylistEntity(Playlist playlist);
 }

--- a/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverter.java
+++ b/src/main/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverter.java
@@ -14,7 +14,8 @@ import org.mapstruct.Mapping;
 }, componentModel = "spring")
 public interface PlaylistDtoConverter {
 
+    @Mapping(target = "id", expression = "java( playlist.getId().value() )")
     @Mapping(target = "owner", source = "playlistOwner")
-    @Mapping(target = "contextUri", expression = "java( \"sonata:playlist:\" + playlist.getId() )")
+    @Mapping(target = "contextUri", expression = "java( playlist.getContextUri().asString() )")
     PlaylistDto toPlaylistDto(Playlist playlist);
 }

--- a/src/test/java/com/odeyalo/sonata/playlists/controller/AddItemToPlaylistEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/controller/AddItemToPlaylistEndpointTest.java
@@ -90,7 +90,7 @@ class AddItemToPlaylistEndpointTest {
         @Bean
         @Primary
         public PlaylistService testPlaylistService() {
-            final Playlist playlist = PlaylistFaker.createWithNoId().setId(EXISTING_PLAYLIST_ID).withPlaylistOwnerId(USER_ID).get();
+            final Playlist playlist = PlaylistFaker.create().setId(EXISTING_PLAYLIST_ID).withPlaylistOwnerId(USER_ID).get();
             return PlaylistServices.withPlaylists(playlist);
         }
 

--- a/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistEndpointTest.java
@@ -97,7 +97,7 @@ public class FetchPlaylistEndpointTest {
 
             PlaylistDto body = responseSpec.expectBody(PlaylistDto.class).returnResult().getResponseBody();
 
-            PlaylistDtoAssert.forPlaylist(body).id().isEqualTo(existingPlaylist.getId());
+            PlaylistDtoAssert.forPlaylist(body).id().isEqualTo(existingPlaylist.getId().value());
         }
 
         @Test
@@ -133,7 +133,7 @@ public class FetchPlaylistEndpointTest {
 
             PlaylistDto body = responseSpec.expectBody(PlaylistDto.class).returnResult().getResponseBody();
 
-            PlaylistDtoAssert.forPlaylist(body).contextUri().isEqualTo("sonata:playlist:" + existingPlaylist.getId());
+            PlaylistDtoAssert.forPlaylist(body).contextUri().isEqualTo("sonata:playlist:" + existingPlaylist.getId().value());
         }
 
         @Test
@@ -146,7 +146,7 @@ public class FetchPlaylistEndpointTest {
         }
 
         private WebTestClient.ResponseSpec prepareAndSend() {
-            return sendRequest(existingPlaylist.getId());
+            return sendRequest(existingPlaylist.getId().value());
         }
     }
 
@@ -203,7 +203,7 @@ public class FetchPlaylistEndpointTest {
             PLAYLIST_ID = playlistService.create(
                     playlistInfo,
                     PlaylistOwner.of(PLAYLIST_OWNER_ID, "odeyalkoo", EntityType.USER)
-            ).block().getId();
+            ).block().getId().value();
         }
 
         @Test

--- a/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistEndpointTest.java
@@ -13,9 +13,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.NestedTestConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Hooks;
@@ -25,9 +23,7 @@ import testing.spring.AutoConfigureSonataStubs;
 import static com.odeyalo.sonata.playlists.model.PlaylistType.PRIVATE;
 import static com.odeyalo.sonata.playlists.model.PlaylistType.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.CLASSPATH;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.context.NestedTestConfiguration.EnclosingConfiguration.OVERRIDE;
 
 
 @SpringBootTest
@@ -190,8 +186,6 @@ public class FetchPlaylistEndpointTest {
     }
 
     @Nested
-    @AutoConfigureStubRunner(stubsMode = CLASSPATH, ids = "com.odeyalo.sonata:authorization:+")
-    @NestedTestConfiguration(OVERRIDE)
     class NotPlaylistOwnerRequestTest {
         final String OTHER_USER_TOKEN = "Bearer ilovemikunakano";
         String PLAYLIST_ID;

--- a/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistTracksEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/controller/FetchPlaylistTracksEndpointTest.java
@@ -121,7 +121,7 @@ class FetchPlaylistTracksEndpointTest {
         @Bean
         @Primary
         public PlaylistService testPlaylistService() {
-            final Playlist playlist = PlaylistFaker.createWithNoId()
+            final Playlist playlist = PlaylistFaker.create()
                     .setId(EXISTING_PLAYLIST_ID)
                     .withPlaylistOwnerId(PLAYLIST_OWNER_ID)
                     .setPlaylistType(PRIVATE)

--- a/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistOperationsTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistOperationsTest.java
@@ -18,7 +18,7 @@ class DefaultPlaylistOperationsTest {
 
         testable.createPlaylist(playlistInfo, owner)
                 .as(StepVerifier::create)
-                .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId()))
+                .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId().value()))
                 .verifyComplete();
     }
 
@@ -31,9 +31,9 @@ class DefaultPlaylistOperationsTest {
         Playlist createdPlaylist = testable.createPlaylist(playlistInfo, owner).block();
 
         //noinspection DataFlowIssue
-        testable.findById(createdPlaylist.getId())
+        testable.findById(createdPlaylist.getId().value())
                 .as(StepVerifier::create)
-                .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId()))
+                .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId().value()))
                 .verifyComplete();
     }
 }

--- a/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
@@ -63,7 +63,7 @@ class DefaultPlaylistServiceTest {
         //noinspection DataFlowIssue
         final Playlist updatedPlaylist = Playlist.from(savedPlaylist).name("new name!").build();
         // when
-        testable.save(updatedPlaylist)
+        testable.update(updatedPlaylist)
                 .as(StepVerifier::create)
                 // then
                 .assertNext(it -> assertThat(it.getName()).isEqualTo("new name!"))

--- a/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
@@ -57,7 +57,7 @@ class DefaultPlaylistServiceTest {
         testable.create(createPlaylistInfo, PLAYLIST_OWNER)
                 .as(StepVerifier::create)
                 // then
-                .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId()))
+                .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId().value()))
                 .verifyComplete();
     }
 
@@ -87,7 +87,7 @@ class DefaultPlaylistServiceTest {
 
         // then
         //noinspection DataFlowIssue
-        final Playlist found = testable.loadPlaylist(saved.getId()).block();
+        final Playlist found = testable.loadPlaylist(saved.getId().value()).block();
 
         assertThat(saved).isEqualTo(found);
     }

--- a/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
@@ -18,7 +18,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldReturnPlaylistNameSameToProvided() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
 
         final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
 
@@ -33,7 +33,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldGenerateIdForNewPlaylist() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
 
         final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
 
@@ -48,7 +48,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldGenerateContextUriForNewPlaylist() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
 
         final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
 
@@ -63,7 +63,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldUpdateExistingPlaylist() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
 
         final Playlist savedPlaylist = testable.create(CreatePlaylistInfo.withName("old name :("), PLAYLIST_OWNER).block();
 
@@ -80,7 +80,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldReturnExistingPlaylist() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
         // when
         final Playlist saved = testable.create(CreatePlaylistInfo.withName("old name :("), PLAYLIST_OWNER).block();
 
@@ -94,7 +94,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldReturnNothingIfPlaylistDoesNotExistByProvidedId() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
         // when
         testable.loadPlaylist("not_existing")
                 .as(StepVerifier::create)

--- a/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
@@ -7,12 +7,13 @@ import com.odeyalo.sonata.playlists.support.converter.*;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
-import testing.faker.PlaylistFaker;
 import testing.faker.PlaylistOwnerFaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DefaultPlaylistServiceTest {
+
+    public static final PlaylistOwner PLAYLIST_OWNER = PlaylistOwnerFaker.create().get();
 
     @Test
     void shouldReturnPlaylistNameSameToProvided() {
@@ -20,10 +21,9 @@ class DefaultPlaylistServiceTest {
         final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
 
         final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
-        final PlaylistOwner owner = PlaylistOwnerFaker.create().get();
 
         // when
-        testable.create(createPlaylistInfo, owner)
+        testable.create(createPlaylistInfo, PLAYLIST_OWNER)
                 .as(StepVerifier::create)
                 // then
                 .assertNext(it -> assertThat(it.getName()).isEqualTo("Lo-Fi"))
@@ -36,10 +36,9 @@ class DefaultPlaylistServiceTest {
         final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
 
         final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
-        final PlaylistOwner owner = PlaylistOwnerFaker.create().get();
 
         // when
-        testable.create(createPlaylistInfo, owner)
+        testable.create(createPlaylistInfo, PLAYLIST_OWNER)
                 .as(StepVerifier::create)
                 // then
                 .assertNext(it -> assertThat(it.getId()).isNotNull())
@@ -52,10 +51,9 @@ class DefaultPlaylistServiceTest {
         final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
 
         final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
-        final PlaylistOwner owner = PlaylistOwnerFaker.create().get();
 
         // when
-        testable.create(createPlaylistInfo, owner)
+        testable.create(createPlaylistInfo, PLAYLIST_OWNER)
                 .as(StepVerifier::create)
                 // then
                 .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId()))
@@ -67,9 +65,7 @@ class DefaultPlaylistServiceTest {
         // given
         final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
 
-        final Playlist playlist = PlaylistFaker.createWithNoId().get();
-
-        final Playlist savedPlaylist = testable.save(playlist).block();
+        final Playlist savedPlaylist = testable.create(CreatePlaylistInfo.withName("old name :("), PLAYLIST_OWNER).block();
 
         //noinspection DataFlowIssue
         final Playlist updatedPlaylist = Playlist.from(savedPlaylist).name("new name!").build();
@@ -82,14 +78,15 @@ class DefaultPlaylistServiceTest {
     }
 
     @Test
-    void savedPlaylistShouldBeFound() {
+    void shouldReturnExistingPlaylist() {
         // given
-        final Playlist playlist = PlaylistFaker.create().get();
         final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
         // when
-        final Playlist saved = testable.save(playlist).block();
+        final Playlist saved = testable.create(CreatePlaylistInfo.withName("old name :("), PLAYLIST_OWNER).block();
+
         // then
-        final Playlist found = testable.loadPlaylist(playlist.getId()).block();
+        //noinspection DataFlowIssue
+        final Playlist found = testable.loadPlaylist(saved.getId()).block();
 
         assertThat(saved).isEqualTo(found);
     }

--- a/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
@@ -1,27 +1,32 @@
 package com.odeyalo.sonata.playlists.service;
 
 import com.odeyalo.sonata.playlists.model.Playlist;
+import com.odeyalo.sonata.playlists.model.PlaylistOwner;
 import com.odeyalo.sonata.playlists.repository.InMemoryPlaylistRepository;
 import com.odeyalo.sonata.playlists.support.converter.*;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import testing.faker.PlaylistFaker;
+import testing.faker.PlaylistOwnerFaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DefaultPlaylistServiceTest {
 
     @Test
-    void shouldSavePlaylistIfPlaylistHasNoId() {
+    void shouldReturnPlaylistNameSameToProvided() {
         // given
         final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
-        final Playlist playlist = PlaylistFaker.createWithNoId().get();
+
+        final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
+        final PlaylistOwner owner = PlaylistOwnerFaker.create().get();
+
         // when
-        testable.save(playlist)
+        testable.create(createPlaylistInfo, owner)
                 .as(StepVerifier::create)
                 // then
-                .assertNext(it -> assertThat(it).usingRecursiveComparison().ignoringFields("id", "contextUri").isEqualTo(playlist))
+                .assertNext(it -> assertThat(it.getName()).isEqualTo("Lo-Fi"))
                 .verifyComplete();
     }
 
@@ -29,9 +34,12 @@ class DefaultPlaylistServiceTest {
     void shouldGenerateIdForNewPlaylist() {
         // given
         final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
-        final Playlist playlist = PlaylistFaker.createWithNoId().get();
+
+        final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
+        final PlaylistOwner owner = PlaylistOwnerFaker.create().get();
+
         // when
-        testable.save(playlist)
+        testable.create(createPlaylistInfo, owner)
                 .as(StepVerifier::create)
                 // then
                 .assertNext(it -> assertThat(it.getId()).isNotNull())
@@ -42,9 +50,12 @@ class DefaultPlaylistServiceTest {
     void shouldGenerateContextUriForNewPlaylist() {
         // given
         final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter());
-        final Playlist playlist = PlaylistFaker.createWithNoId().get();
+
+        final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
+        final PlaylistOwner owner = PlaylistOwnerFaker.create().get();
+
         // when
-        testable.save(playlist)
+        testable.create(createPlaylistInfo, owner)
                 .as(StepVerifier::create)
                 // then
                 .assertNext(it -> assertThat(it.getContextUri().asString()).isEqualTo("sonata:playlist:" + it.getId()))

--- a/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/DefaultPlaylistServiceTest.java
@@ -1,5 +1,6 @@
 package com.odeyalo.sonata.playlists.service;
 
+import com.odeyalo.sonata.playlists.config.factory.FactoryConfiguration;
 import com.odeyalo.sonata.playlists.model.Playlist;
 import com.odeyalo.sonata.playlists.model.PlaylistOwner;
 import com.odeyalo.sonata.playlists.repository.InMemoryPlaylistRepository;
@@ -18,7 +19,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldReturnPlaylistNameSameToProvided() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory(), new FactoryConfiguration().playlistEntityFactory());
 
         final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
 
@@ -33,7 +34,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldGenerateIdForNewPlaylist() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory(), new FactoryConfiguration().playlistEntityFactory());
 
         final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
 
@@ -48,7 +49,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldGenerateContextUriForNewPlaylist() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory(), new FactoryConfiguration().playlistEntityFactory());
 
         final CreatePlaylistInfo createPlaylistInfo = CreatePlaylistInfo.withName("Lo-Fi");
 
@@ -63,7 +64,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldUpdateExistingPlaylist() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory(), new FactoryConfiguration().playlistEntityFactory());
 
         final Playlist savedPlaylist = testable.create(CreatePlaylistInfo.withName("old name :("), PLAYLIST_OWNER).block();
 
@@ -80,7 +81,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldReturnExistingPlaylist() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory(), new FactoryConfiguration().playlistEntityFactory());
         // when
         final Playlist saved = testable.create(CreatePlaylistInfo.withName("old name :("), PLAYLIST_OWNER).block();
 
@@ -94,7 +95,7 @@ class DefaultPlaylistServiceTest {
     @Test
     void shouldReturnNothingIfPlaylistDoesNotExistByProvidedId() {
         // given
-        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory());
+        final DefaultPlaylistService testable = new DefaultPlaylistService(new InMemoryPlaylistRepository(), createPlaylistConverter(), new Playlist.Factory(), new FactoryConfiguration().playlistEntityFactory());
         // when
         testable.loadPlaylist("not_existing")
                 .as(StepVerifier::create)

--- a/src/test/java/com/odeyalo/sonata/playlists/service/tracks/DefaultPlaylistItemsOperationsTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/service/tracks/DefaultPlaylistItemsOperationsTest.java
@@ -524,7 +524,8 @@ class DefaultPlaylistItemsOperationsTest {
             this.playlistLoader = PlaylistLoaders.withPlaylists(playlists);
             if ( itemsRepository == null ) {
                 this.itemsRepository = PlaylistItemsRepositories.withPlaylistIds(Arrays.stream(playlists)
-                        .map(Playlist::getId).collect(Collectors.toSet()));
+                        .map(playlist -> playlist.getId().value())
+                        .collect(Collectors.toSet()));
             }
             return this;
         }

--- a/src/test/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverterTest.java
+++ b/src/test/java/com/odeyalo/sonata/playlists/support/converter/PlaylistDtoConverterTest.java
@@ -27,7 +27,7 @@ class PlaylistDtoConverterTest {
 
         PlaylistDto playlistDto = playlistDtoConverter.toPlaylistDto(playlist);
 
-        forPlaylist(playlistDto).id().isEqualTo(playlist.getId());
+        forPlaylist(playlistDto).id().isEqualTo(playlist.getId().value());
         forPlaylist(playlistDto).name().isEqualTo(playlist.getName());
         forPlaylist(playlistDto).description().isEqualTo(playlist.getDescription());
         forPlaylist(playlistDto).playlistType().isEqualTo(playlist.getPlaylistType());

--- a/src/test/java/testing/factory/PlaylistOperationsTestableFactory.java
+++ b/src/test/java/testing/factory/PlaylistOperationsTestableFactory.java
@@ -19,7 +19,7 @@ public class PlaylistOperationsTestableFactory {
 
     public static DefaultPlaylistOperations create() {
         final InMemoryPlaylistRepository repository = new InMemoryPlaylistRepository();
-        return new DefaultPlaylistOperations(new DefaultPlaylistService(repository, createPlaylistConverter()), new MockImageUploader());
+        return new DefaultPlaylistOperations(new DefaultPlaylistService(repository, createPlaylistConverter(), new Playlist.Factory()), new MockImageUploader());
     }
 
     @NotNull

--- a/src/test/java/testing/factory/PlaylistOperationsTestableFactory.java
+++ b/src/test/java/testing/factory/PlaylistOperationsTestableFactory.java
@@ -1,5 +1,6 @@
 package testing.factory;
 
+import com.odeyalo.sonata.playlists.config.factory.FactoryConfiguration;
 import com.odeyalo.sonata.playlists.model.Playlist;
 import com.odeyalo.sonata.playlists.repository.InMemoryPlaylistRepository;
 import com.odeyalo.sonata.playlists.service.DefaultPlaylistOperations;
@@ -19,7 +20,7 @@ public class PlaylistOperationsTestableFactory {
 
     public static DefaultPlaylistOperations create() {
         final InMemoryPlaylistRepository repository = new InMemoryPlaylistRepository();
-        return new DefaultPlaylistOperations(new DefaultPlaylistService(repository, createPlaylistConverter(), new Playlist.Factory()), new MockImageUploader());
+        return new DefaultPlaylistOperations(new DefaultPlaylistService(repository, createPlaylistConverter(), new Playlist.Factory(), new FactoryConfiguration().playlistEntityFactory()), new MockImageUploader());
     }
 
     @NotNull

--- a/src/test/java/testing/factory/PlaylistServices.java
+++ b/src/test/java/testing/factory/PlaylistServices.java
@@ -1,0 +1,22 @@
+package testing.factory;
+
+import com.odeyalo.sonata.playlists.model.Playlist;
+import com.odeyalo.sonata.playlists.service.InMemoryPlaylistService;
+import com.odeyalo.sonata.playlists.service.PlaylistService;
+
+import java.util.List;
+
+public final class PlaylistServices {
+
+    public static PlaylistService withPlaylists(final Playlist... playlists) {
+        return withPlaylists(List.of(playlists));
+    }
+
+    public static PlaylistService withPlaylists(final List<Playlist> playlists) {
+        return new InMemoryPlaylistService(playlists);
+    }
+
+    public static PlaylistService empty() {
+        return withPlaylists();
+    }
+}

--- a/src/test/java/testing/faker/PlaylistFaker.java
+++ b/src/test/java/testing/faker/PlaylistFaker.java
@@ -1,11 +1,7 @@
 package testing.faker;
 
 import com.github.javafaker.Faker;
-import com.odeyalo.sonata.playlists.model.Images;
-import com.odeyalo.sonata.playlists.model.Playlist;
-import com.odeyalo.sonata.playlists.model.PlaylistOwner;
-import com.odeyalo.sonata.playlists.model.PlaylistType;
-import org.apache.commons.lang3.RandomStringUtils;
+import com.odeyalo.sonata.playlists.model.*;
 
 /**
  * Create a faked {@link Playlist} that can be used in tests
@@ -13,13 +9,16 @@ import org.apache.commons.lang3.RandomStringUtils;
 public class PlaylistFaker {
     private final Playlist.PlaylistBuilder builder = Playlist.builder();
 
-    private Faker faker = Faker.instance();
+    private final Faker faker = Faker.instance();
 
     public PlaylistFaker() {
+        final PlaylistId playlistId = PlaylistId.random();
+
         builder
-                .id(RandomStringUtils.randomAlphanumeric(16))
+                .id(playlistId)
                 .name(faker.name().title())
                 .description(faker.weather().description())
+                .contextUri(playlistId.asContextUri())
                 .playlistType(faker.options().option(PlaylistType.class))
                 .playlistOwner(PlaylistOwnerFaker.create().get());
     }
@@ -29,7 +28,7 @@ public class PlaylistFaker {
     }
 
     public PlaylistFaker setId(String id) {
-        builder.id(id);
+        builder.id(PlaylistId.of(id));
         return this;
     }
 

--- a/src/test/java/testing/faker/PlaylistFaker.java
+++ b/src/test/java/testing/faker/PlaylistFaker.java
@@ -16,7 +16,8 @@ public class PlaylistFaker {
     private Faker faker = Faker.instance();
 
     public PlaylistFaker() {
-        builder.id(RandomStringUtils.randomAlphanumeric(16))
+        builder
+                .id(RandomStringUtils.randomAlphanumeric(16))
                 .name(faker.name().title())
                 .description(faker.weather().description())
                 .playlistType(faker.options().option(PlaylistType.class))
@@ -26,11 +27,6 @@ public class PlaylistFaker {
     public static PlaylistFaker create() {
         return new PlaylistFaker();
     }
-
-    public static PlaylistFaker createWithNoId() {
-        return new PlaylistFaker().setId(null);
-    }
-
 
     public PlaylistFaker setId(String id) {
         builder.id(id);


### PR DESCRIPTION
Split the save() method to two separated methods in PlaylistService and implementations:

- create(CreatePlaylistInfo, PlaylistOwner) to create a playlist
- update(Playlist) to update the given playlist. 
- Refactor of Playlist class: migrated String id to PlaylistId value object

Moved creation of Playlist and PlaylistEntity to factories instead of converters